### PR TITLE
Work around items with empty requests or responses.

### DIFF
--- a/convert-burp-suite-http-proxy-history-to-csv.py
+++ b/convert-burp-suite-http-proxy-history-to-csv.py
@@ -63,11 +63,17 @@ def convert_to_output_file(http_history, format_handler):
             format_handler.row_column(line['method'])
             format_handler.row_column(line['path'])
             format_handler.row_column(line['extension'])
-            format_handler.row_column(line['request']['#text'], encoded=True)
+            if '#text' in line['request']:
+                format_handler.row_column(line['request']['#text'], encoded=True)
+            else:
+                format_handler.row_column("None")
             format_handler.row_column(line['status'])
             format_handler.row_column(line['responselength'])
             format_handler.row_column(line['mimetype'])
-            format_handler.row_column(line['response']['#text'], encoded=True)
+            if '#text' in line['response']:
+                format_handler.row_column(line['response']['#text'], encoded=True)
+            else:
+                format_handler.row_column("None")
             format_handler.row_column(line['comment'])
             format_handler.row_suffix()
         format_handler.footer()


### PR DESCRIPTION
I had a fairly large (several GB, hundreds of thousands of records)
history created with Burp 1.7.23.  Sometimes the server had crashed or
otherwise failed to ever respond to Burp, and the saved response was
empty:

    <responselength></responselength>
    <mimetype></mimetype>
    <response base64="true"></response>

convert-burp-suite-http-proxy-history-to-csv.py was blowing up the
first time it encountered such a case, with an error that boiled
down to:

  line 70, in convert_to_output_file
      format_handler.row_column(line['response']['#text'], encoded=True)
  KeyError: u'#text'

I am a useless Python programmer but it seemed to me that when the
response was empty, the key #text was undefined, causing this error.
This patch adds sanity checking to work around these; I check
'request' too although I do not know that that can ever be blank.