### PR TITLE
Work around UTF-8 decode errors.

### DIFF
--- a/convert-burp-suite-http-proxy-history-to-csv.py
+++ b/convert-burp-suite-http-proxy-history-to-csv.py
@@ -77,7 +77,11 @@ def parse_http_history(filename):
         return xmltodict.parse(f)
 
 def base64decode(line):
-    return base64.b64decode(line).decode('UTF-8')
+    try:
+        decoded = base64.b64decode(line).decode('UTF-8')
+        return decoded
+    except:
+        return "[corrupt]"
 
 def set_csv_delimiter(csv_delimiter):
     if csv_delimiter:


### PR DESCRIPTION
Out of a couple hundred thousand entries in my Burp project history,
a few responses decoded to invalid UTF-8 data, causing errors like:

    File ".../convert-burp-suite-http-proxy-history-to-csv.py", line 80, in base64decode
      return base64.b64decode(line).decode('UTF-8')
    File "/usr/lib64/python2.7/encodings/utf_8.py", line 16, in decode
      return codecs.utf_8_decode(input, errors, True)
  UnicodeDecodeError: 'utf8' codec can't decode byte 0xaa in position 242: invalid start byte

Indeed when I identified the offending entry, extracted the CDATA
and sent it through base64 -d by hand, that also complained.

It would be nice to recover as much of the content from such a
transaction as possible, but more important to me is to not abort
the entire conversion.  So, this patch wraps the decode that was
blowing up for me.  I'm sure there is a better way to do this, but
it's tired and I'm late.

Note that I separated this change out from the
empty-response-workaround change that I submitted a PR for just a few
minutes ago; they are both against the same master branch.