### PR TITLE
python3 specify read binary when opening xml file

### DIFF
--- a/convert-burp-suite-http-proxy-history-to-csv.py
+++ b/convert-burp-suite-http-proxy-history-to-csv.py
@@ -79,7 +79,7 @@ def convert_to_output_file(http_history, format_handler):
         format_handler.footer()
 
 def parse_http_history(filename):
-    with open(filename) as f:
+    with open(filename, 'rb') as f:
         return xmltodict.parse(f)
 
 def base64decode(line):


### PR DESCRIPTION
resolves issue#5
someone should test in python2 first to be sure it does not break