### PR TITLE
renamed unicode to str to support python 3

### DIFF
--- a/convert-burp-suite-http-proxy-history-to-csv.py
+++ b/convert-burp-suite-http-proxy-history-to-csv.py
@@ -208,4 +208,7 @@ FORMATS = {
 }
 
 if __name__ == '__main__':
+    # In python 3, unicode is renamed to str
+    if sys.version_info[0] >= 3:
+      unicode = str
     main()


### PR DESCRIPTION
In Python 3, unicode is renamed to str. Added the check before main to rename unicode to str if python 3 is used.
Ref: https://stackoverflow.com/questions/19877306/nameerror-global-name-unicode-is-not-defined-in-python-3